### PR TITLE
Update app manifest to allow for running local/prod side-by-side

### DIFF
--- a/GhostOverlay/Package.appxmanifest
+++ b/GhostOverlay/Package.appxmanifest
@@ -8,7 +8,7 @@
 	IgnorableNamespaces="uap mp uap3">
 
 	<Identity
-		Name="WorldClassDevelopmentLtd.GhostOverlay"
+		Name="WorldClassDevelopmentLtd.GhostOverlay.Dev"
 		Publisher="CN=F78EA302-9D46-44EB-A662-246312A8DD23"
 		Version="1.0.1.0" />
 
@@ -16,7 +16,7 @@
 					  PhonePublisherId="00000000-0000-0000-0000-000000000000"/>
 
 	<Properties>
-		<DisplayName>Ghost Overlay</DisplayName>
+		<DisplayName>Ghost Overlay (Dev)</DisplayName>
 		<PublisherDisplayName>World Class Development Ltd</PublisherDisplayName>
 		<Logo>Assets\AppIcon\StoreLogo.png</Logo>
 	</Properties>
@@ -36,7 +36,7 @@
 					 Executable="$targetnametoken$.exe"
 					 EntryPoint="GhostOverlay.App">
 			<uap:VisualElements
-				DisplayName="Ghost Overlay"
+				DisplayName="Ghost Overlay (Dev)"
 				Square150x150Logo="Assets\AppIcon\Square150x150Logo.png"
 				Description="Ghost Overlay"
 				AppListEntry="none"
@@ -53,7 +53,7 @@
 				<uap3:Extension Category="windows.appExtension">
 					<uap3:AppExtension Name="microsoft.gameBarUIExtension"
 					                   Id="WidgetMain"
-					                   DisplayName="Ghost Overlay"
+					                   DisplayName="Ghost Overlay (Dev)"
 					                   PublicFolder="GameBarAssets"
 					                   Description="Overlay quest information for Destiny 2">
 						<uap3:Properties>
@@ -83,7 +83,7 @@
 					<uap3:AppExtension Name="microsoft.gameBarUIExtension"
 					                   Id="WidgetMainSettings"
 					                   PublicFolder="GameBarAssets"
-					                   DisplayName="Ghost Overlay Settings"
+					                   DisplayName="Ghost Overlay Settings (Dev)"
 					                   Description="Ghost Overlay Settings">
 						<uap3:Properties>
 							<GameBarWidget Type="Settings">
@@ -105,7 +105,7 @@
 
 				<uap:Extension Category="windows.protocol">
 					<uap:Protocol Name="ghost-overlay">
-						<uap:DisplayName>Ghost Overlay</uap:DisplayName>
+						<uap:DisplayName>Ghost Overlay (Dev)</uap:DisplayName>
 					</uap:Protocol>
 				</uap:Extension>
 			</Extensions>


### PR DESCRIPTION
Addresses #6 
By appending a `.Dev` to the identity name of the app when deploying locally the windows store will allow you to install the version of the app currently available in the store (windows thinks that they are two separate apps). You can tell them apart from one another if you append a (Dev) to the display name of the app wherever it appears in the manifest. You can deploy locally and you can compare your changes against the current production version.
![image](https://user-images.githubusercontent.com/21179656/83335801-e891d980-a274-11ea-8582-000b6c3c76a3.png)

Whenever you want to push an updated version to the windows store you'll have to remove the `.Dev` from the identity name or the store will think you're trying to publish a new application. You'll also have to remove the (Dev) from the display names.